### PR TITLE
Custom values from Wizard (#27)

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -269,6 +269,31 @@ class ProductTemplate(models.Model):
         return img_obj
 
     @api.multi
+    def encode_custom_values(self, custom_values):
+        """ Hook to alter the values of the custom values before creating or writing
+
+            :param custom_values: dict {product.attribute.id: custom_value}
+
+            :returns: list of custom values compatible with write and create
+        """
+        binary_attribute_ids = self.env['product.attribute'].search([
+            ('custom_type', '=', 'binary')]).ids
+
+        custom_lines = []
+
+        for key, val in custom_values.iteritems():
+            custom_vals = {'attribute_id': key}
+            if key in binary_attribute_ids:
+                custom_vals.update({
+                    'attachment_ids': [(6, 0, val.ids)]
+                })
+            else:
+                self.env['product.attribute'].browse(key).validate_custom_val(val)
+                custom_vals.update({'value': val})
+            custom_lines.append((0, 0, custom_vals))
+        return custom_lines
+
+    @api.multi
     def get_variant_vals(self, value_ids, custom_values=None, **kwargs):
         """ Hook to alter the values of the product variant before creation
 
@@ -278,8 +303,6 @@ class ProductTemplate(models.Model):
             :returns: dictionary of values to pass to product.create() method
          """
         self.ensure_one()
-        if custom_values is None:
-            custom_values = {}
 
         image = self.get_config_image_obj(value_ids).image
         all_images = tools.image_get_resized_images(
@@ -294,24 +317,8 @@ class ProductTemplate(models.Model):
             'image_small': all_images['image_medium'],
         }
 
-        binary_attribute_ids = self.env['product.attribute'].search([
-            ('custom_type', '=', 'binary')]).ids
-
-        if not custom_values:
-            return vals
-
-        custom_lines = []
-
-        for key, val in custom_values.iteritems():
-            custom_vals = {'attribute_id': key}
-            if key in binary_attribute_ids:
-                custom_vals.update({
-                    'attachment_ids': [(6, 0, val.ids)]
-                })
-            else:
-                custom_vals.update({'value': val})
-            custom_lines.append((0, 0, custom_vals))
-        vals.update({'value_custom_ids': custom_lines})
+        if custom_values:
+            vals.update({'value_custom_ids': self.encode_custom_values(custom_values)})
 
         return vals
 

--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -2,6 +2,7 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from ast import literal_eval
 
 # TODO: Implement a default attribute value field/method to load up on wizard
 
@@ -100,6 +101,19 @@ class ProductAttribute(models.Model):
                   self.custom_type)
             )
 
+    def validate_custom_val(self, val):
+        """ Pass in a desired custom value and ensure it is valid.
+        Probaly should check type, etc, but let's assume fine for the moment.
+        """ 
+        self.ensure_one()
+        if self.custom_type in ('int', 'float'):
+            if self.min_val or self.max_val:
+                val = literal_eval(val)
+                if val < self.min_val or val > self.max_val:
+                    raise ValidationError(
+                        _("Selected custom value '%s' must be between %s and %s" %
+                          (self.name, self.min_val, self.max_val))
+                    )
 
 class ProductAttributeLine(models.Model):
     _inherit = 'product.attribute.line'

--- a/product_configurator_wizard/models/sale.py
+++ b/product_configurator_wizard/models/sale.py
@@ -23,7 +23,8 @@ class SaleOrderLine(models.Model):
         wizard_obj = self.env['product.configurator']
         wizard = wizard_obj.create({
             'product_id': self.product_id.id,
-            'state': active_step
+            'state': active_step,
+            'order_line_id': self.id,
         })
 
         return {


### PR DESCRIPTION
* New method created in wizard for translating custom values correctly after reconfiguring

* Custom values being written were ignored if the main field was not being submitted. 

* Allow a False value to be stored for a custom value.

* Custom Values need to be validated.

* Hooks to allow functions to alter SO lines based on the configuration.

* Unlink custom values if changing from custom value to selected value